### PR TITLE
Update schedule url

### DIFF
--- a/index.md
+++ b/index.md
@@ -394,7 +394,7 @@ of code below the Schedule `<h2>` header below with
 {% elsif info.carpentry == "lc" %}
 {% include lc/schedule.html %}
 {% elsif info.carpentry == "ds" %}
-{% remote_include {{lesson_meta}}/schedule-3days.md %}
+{% remote_include {{lesson_meta}}/schedule.md %}
 {% elsif info.carpentry == "pilot" %}
 The lesson taught in this workshop is being piloted and a precise schedule is yet to be established. The workshop will include regular breaks. If you would like to know the timing of these breaks in advance, please [contact the workshop organisers](#contact). For a list of lesson sections and estimated timings, [visit the lesson homepage]({{ site.lesson_site }}).
 {% comment %}


### PR DESCRIPTION
To match with: https://github.com/esciencecenter-digital-skills/workshop-metadata/commit/af4fbf91fee7ba9817d3bdd3d22dfacdc0e569b6

The 3-day schedule is the default now. (Note that the current website still works properly, but if you would make a new release it would search for the old url and that would break)